### PR TITLE
feat: add Gravity to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
       - name: build and check generated types
         if: (${{ success() }} || ${{ failure() }}) # ensures this step runs even if previous steps fail
         run: pnpm build && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please regenerate types locally with `cd packages/svelte && pnpm generate:types` and commit the changes after you have reviewed them"; git diff; exit 1); }
+      - name: bundle
+        run: pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js
+      - name: gravity
+        run: pnpx @gravityci/cli 'packages/svelte/compiler/**/*.js' 'packages/svelte/dist/index-client.js'
+        env:
+          GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
+
   Benchmarks:
     permissions: {}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         if: (${{ success() }} || ${{ failure() }}) # ensures this step runs even if previous steps fail
         run: pnpm build && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please regenerate types locally with `cd packages/svelte && pnpm generate:types` and commit the changes after you have reviewed them"; git diff; exit 1); }
       - name: bundle
-        run: pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js --minify
+        run: NODE_ENV=production pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js --minify
       - name: gravity
         run: pnpx @gravityci/cli 'packages/svelte/compiler/**/*.js' 'packages/svelte/dist/index-client.js'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,11 @@ jobs:
         if: (${{ success() }} || ${{ failure() }}) # ensures this step runs even if previous steps fail
         run: pnpm build && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please regenerate types locally with `cd packages/svelte && pnpm generate:types` and commit the changes after you have reviewed them"; git diff; exit 1); }
       - name: bundle
-        run: NODE_ENV=production pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js --minify
+        run: |
+          NODE_ENV=production pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js --minify --platform=browser
+          NODE_ENV=production pnpx esbuild ./packages/svelte/src/index-server.js --bundle --format=esm --outfile=packages/svelte/dist/index-server.js --minify --platform=node
       - name: gravity
-        run: pnpx @gravityci/cli 'packages/svelte/compiler/**/*.js' 'packages/svelte/dist/index-client.js'
+        run: pnpx @gravityci/cli 'packages/svelte/compiler/**/*.js' 'packages/svelte/dist/**/*'
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         if: (${{ success() }} || ${{ failure() }}) # ensures this step runs even if previous steps fail
         run: pnpm build && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please regenerate types locally with `cd packages/svelte && pnpm generate:types` and commit the changes after you have reviewed them"; git diff; exit 1); }
       - name: bundle
-        run: pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js
+        run: pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js --minify
       - name: gravity
         run: pnpx @gravityci/cli 'packages/svelte/compiler/**/*.js' 'packages/svelte/dist/index-client.js'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,43 +62,8 @@ jobs:
       - name: build and check generated types
         if: (${{ success() }} || ${{ failure() }}) # ensures this step runs even if previous steps fail
         run: pnpm build && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please regenerate types locally with `cd packages/svelte && pnpm generate:types` and commit the changes after you have reviewed them"; git diff; exit 1); }
-      - name: bundle
-        run: |
-          NODE_ENV=production pnpx esbuild \
-          ./packages/svelte/src/index-client.js \
-          ./packages/svelte/src/animate/index.js \
-          ./packages/svelte/src/internal/client/index.js \
-          ./packages/svelte/src/internal/disclose-version.js \
-          ./packages/svelte/src/internal/flags/legacy.js \
-          ./packages/svelte/src/internal/flags/tracing.js \
-          ./packages/svelte/src/legacy/legacy-client.js \
-          ./packages/svelte/src/motion/index.js \
-          ./packages/svelte/src/reactivity/index-client.js \
-          ./packages/svelte/src/reactivity/window/index.js \
-          ./packages/svelte/src/store/index-client.js \
-          ./packages/svelte/src/transition/index.js \
-          ./packages/svelte/src/events/index.js \
-          --bundle \
-          --format=esm \
-          --outdir=packages/svelte/dist \
-          --minify \
-          --platform=browser
-          NODE_ENV=production pnpx esbuild \
-          ./packages/svelte/src/index-server.js \
-          ./packages/svelte/src/compiler/index.js \
-          ./packages/svelte/src/internal/index.js \
-          ./packages/svelte/src/internal/server/index.js \
-          ./packages/svelte/src/legacy/legacy-server.js \
-          ./packages/svelte/src/reactivity/index-server.js \
-          ./packages/svelte/src/server/index.js \
-          ./packages/svelte/src/store/index-server.js \
-          --bundle \
-          --format=esm \
-          --outdir=packages/svelte/dist \
-          --minify \
-          --platform=node
       - name: gravity
-        run: pnpx @gravityci/cli 'packages/svelte/dist/**/*'
+        run: pnpx @gravityci/cli 'packages/svelte/compiler/**/*.js'
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,41 @@ jobs:
         run: pnpm build && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please regenerate types locally with `cd packages/svelte && pnpm generate:types` and commit the changes after you have reviewed them"; git diff; exit 1); }
       - name: bundle
         run: |
-          NODE_ENV=production pnpx esbuild ./packages/svelte/src/index-client.js --bundle --format=esm --outfile=packages/svelte/dist/index-client.js --minify --platform=browser
-          NODE_ENV=production pnpx esbuild ./packages/svelte/src/index-server.js --bundle --format=esm --outfile=packages/svelte/dist/index-server.js --minify --platform=node
+          NODE_ENV=production pnpx esbuild \
+          ./packages/svelte/src/index-client.js \
+          ./packages/svelte/src/animate/index.js \
+          ./packages/svelte/src/internal/client/index.js \
+          ./packages/svelte/src/internal/disclose-version.js \
+          ./packages/svelte/src/internal/flags/legacy.js \
+          ./packages/svelte/src/internal/flags/tracing.js \
+          ./packages/svelte/src/legacy/legacy-client.js \
+          ./packages/svelte/src/motion/index.js \
+          ./packages/svelte/src/reactivity/index-client.js \
+          ./packages/svelte/src/reactivity/window/index.js \
+          ./packages/svelte/src/store/index-client.js \
+          ./packages/svelte/src/transition/index.js \
+          ./packages/svelte/src/events/index.js \
+          --bundle \
+          --format=esm \
+          --outdir=packages/svelte/dist \
+          --minify \
+          --platform=browser
+          NODE_ENV=production pnpx esbuild \
+          ./packages/svelte/src/index-server.js \
+          ./packages/svelte/src/compiler/index.js \
+          ./packages/svelte/src/internal/index.js \
+          ./packages/svelte/src/internal/server/index.js \
+          ./packages/svelte/src/legacy/legacy-server.js \
+          ./packages/svelte/src/reactivity/index-server.js \
+          ./packages/svelte/src/server/index.js \
+          ./packages/svelte/src/store/index-server.js \
+          --bundle \
+          --format=esm \
+          --outdir=packages/svelte/dist \
+          --minify \
+          --platform=node
       - name: gravity
-        run: pnpx @gravityci/cli 'packages/svelte/compiler/**/*.js' 'packages/svelte/dist/**/*'
+        run: pnpx @gravityci/cli 'packages/svelte/dist/**/*'
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
 


### PR DESCRIPTION
Hi! I'm @oscard0m, and I work at [Mainmatter](https://mainmatter.com).

We really appreciate the great work you're doing at `sveltejs/svelte`! We thought [Gravity](https://gravity.ci) could be useful to the project.

## What is Gravity?

Gravity is a free tool that helps maintainers stay on top of asset size increases as part of their CI pipeline. Gravity catches potentially unintended or disproportionate growth of _bundle_ sizes that result out of code changes in a PR before they hit
  production, e.g. added dependencies that grow the _bundle_ size disproportionally. Without Gravity, it's hard for maintainers to even be aware of these changes, and _bundle_ sizes often just keep growing unnoticed.

Here's a quick video showing Gravity in action:

https://youtu.be/2vD_geF_Ask

You can read a more detailed explanation in our
[blog post](https://gravity.ci/blog/2025/03/19/gravity/).

We also prepared an example PR with Gravity set up on a fork of `sveltejs/svelte`: _[url to PR on fork](https://github.com/mainmatter/svelte/pull/31)_

## Last steps

This PR introduces Gravity to the project, but it is expected the maintainers
take some extra actions to connect all the dots:

1. Install [Gravity GitHub App](https://github.com/apps/gravity-ci) to your organization.
2. Once installed, create a new Gravity project in [https://gravity.ci](https://gravity.ci).
3. [Set up the Gravity token for your repo](https://github.com/<org>/<repo>/settings/secrets/actions) and add the Gravity job to your GitHub Actions workflow.