### PR TITLE
build: replace rollup with esbuild

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -120,7 +120,7 @@
     "templating"
   ],
   "scripts": {
-    "build": "node scripts/process-messages && rollup -c && pnpm generate:types && node scripts/check-treeshakeability.js",
+    "build": "node scripts/process-messages && node scripts/generate-version.js && pnpx esbuild src/compiler/index.js --bundle --format=cjs --global-name=svelte --minify --outfile=compiler/index.js && pnpm generate:types && node scripts/check-treeshakeability.js",
     "dev": "node scripts/process-messages && rollup -cw",
     "check": "tsc --project tsconfig.runtime.json && tsc && cd ./tests/types && tsc",
     "check:watch": "tsc --watch",


### PR DESCRIPTION
Use CJS instead of UMD. They are not equivalent but this is an example committed to show off how Gravity could track bundle size regressions for Svelte compiler

---

here's the PR to setup Gravity if you are curious: https://github.com/mainmatter/svelte/pull/31
